### PR TITLE
adjust to DateTime::Locale 1.33

### DIFF
--- a/t/02_main.t
+++ b/t/02_main.t
@@ -61,7 +61,10 @@ SKIP: {
 	# Expand to a DateTime
 	my $dt = $date->DateTime;
 	# DateTime::Locale version 1.00 changes "C" to "en-US-POSIX".
-	my $expected = eval { DateTime::Locale->VERSION(1) } ? "en-US-POSIX" : "C";
+	# DateTime::Locale version 1.33 changes "en-US-POSIX" to "en_US".
+	my $expected = eval { DateTime::Locale->VERSION(1.33) } ? "en-US" :
+		eval { DateTime::Locale->VERSION(1) } ? "en-US-POSIX" :
+		"C";
 	is( $dt->locale->id,      $expected,  '->locale ok'   );
 	isa_ok( $dt, 'DateTime' );
 	is( $dt->time_zone->name, 'floating', '->timezone ok' );


### PR DESCRIPTION

In Debian we are currently applying the following patch to Date-Tiny.
We thought you might be interested in it too.

    Description: adjust to DateTime::Locale 1.33
    Origin: vendor
    Bug-Debian: https://bugs.debian.org/998560
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2021-11-04
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libdate-tiny-perl/raw/master/debian/patches/DateTime-Locale-1.33.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
